### PR TITLE
Add a py.typed marker file for PEP 561 compliance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ pytest = "^5.4.1"
 pytest-cov = "^2.8.1"
 codecov = "^2.0.22"
 
+
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Greetings,

I begun using this nice library and wanted to use the types and not ignore imports with mypy.

So this PR adds a py.typed and upgrades the poetry build system (I'm not sure the build command under 0.12 automatically puts the py.typed in the file)