### PR TITLE
Correct result type

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ pytest = "^5.4.1"
 pytest-cov = "^2.8.1"
 codecov = "^2.0.22"
 
+
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/sansio_jsonrpc/main.py
+++ b/sansio_jsonrpc/main.py
@@ -104,7 +104,7 @@ class JsonRpcResponse:
     """ Represents a JSON RPC response. """
 
     id: JsonRpcId
-    result: typing.Optional[JsonPrimitive] = None
+    result: typing.Optional[JsonDict] = None
     error: typing.Optional[JsonRpcError] = None
     jsonrpc: str = "2.0"
 
@@ -154,7 +154,7 @@ class JsonRpcResponse:
         return cls(
             id=typing.cast(typing.Union[int, str, None], json_dict["id"]),
             error=error,
-            result=result,
+            result=typing.cast(JsonDict, result),
             jsonrpc=typing.cast(str, json_dict["jsonrpc"]),
         )
 
@@ -206,7 +206,7 @@ class JsonRpcPeer:
         return json.dumps(req.to_json_dict()).encode("utf8")
 
     def respond_with_result(
-        self, request: JsonRpcRequest, result: JsonPrimitive
+        self, request: JsonRpcRequest, result: JsonDict
     ) -> bytes:
         """
         Create a success response to a given request and return a network


### PR DESCRIPTION
Currently the type of a jsonrpc result is a JsonPrimitive while it is a JsonDict in fact,
this PR corrects that, it is built on top of the previous one I sent but I can seperate it if deemed necessary, currently using my forked branch hence why :)